### PR TITLE
Disabled auto docking of drawer

### DIFF
--- a/web/client/src/components/App.js
+++ b/web/client/src/components/App.js
@@ -20,11 +20,11 @@ class App extends ReactCSS.Component {
   }
 
   componentWillMount () {
-    this.props.drawer.mql.addListener(this.props.updateAutoDock);
+    // this.props.drawer.mql.addListener(this.props.updateAutoDock);
   }
 
   componentWillUnmount () {
-    this.props.drawer.mql.removeListener(this.props.updateAutoDock);
+    // this.props.drawer.mql.removeListener(this.props.updateAutoDock);
   }
 
   classes () {

--- a/web/client/src/reducers/drawer.js
+++ b/web/client/src/reducers/drawer.js
@@ -37,7 +37,7 @@ const drawer = handleActions({
   })
 }, {
   isOpen: false,
-  isDocked: mql.matches,
+  isDocked: false,
   mql
 });
 


### PR DESCRIPTION
As per suggestion of @broadstone I've disabled automatic docking for the time being. Maybe at some other venture, maybe when we can associate user accounts with their discord counterparts, the discord widget in the drawer will be less misleading.